### PR TITLE
Optimize CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ defaults: &defaults
     # Restore Hadolint
     - restore_cache:
         keys:
-        # Get latest cache for the current specs
-        - v1-hadolint-{{ arch }}-{{ checksum "/home/atom/.local/bin/hadolint" }}
-        # Fallback to the last available cache
         - v1-hadolint-{{ arch }}
     - run:
         name: Install Haskell

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,142 +1,155 @@
 version: 2
 
 defaults: &defaults
- working_directory: /tmp/project
- docker:
-   - image: circleci/node:latest
-     environment:
-       CIRCLE_BUILD_IMAGE: ubuntu
-       ATOM_CHANNEL: stable
-       DISPLAY: :99
+  working_directory: /tmp/project
+  docker:
+    - image: arcanemagus/atom-docker-ci:stable
+  steps:
+    # Restore project state
+    - attach_workspace:
+        at: /tmp
+    # Restore Hadolint
+    - restore_cache:
+        keys:
+        # Get latest cache for the current specs
+        - v1-hadolint-{{ arch }}-{{ checksum "/home/atom/.local/bin/hadolint" }}
+        # Fallback to the last available cache
+        - v1-hadolint-{{ arch }}
+    - run:
+        name: Install Haskell
+        command: |
+          sudo apt-get update && \
+          sudo apt-get install --assume-yes --quiet --no-install-suggests \
+            --no-install-recommends haskell-platform
+    - run:
+        name: Install Stack
+        command: |
+          curl --location --silent --show-error -o install_stack.sh \
+            https://get.haskellstack.org/ && \
+          sh install_stack.sh && \
+          echo 'export PATH=~/.local/bin:$PATH' >> $BASH_ENV
+    - run:
+        name: Haskell version
+        command: ghc --version
+    - run:
+        name: Stack version
+        command: stack --version
+    - run:
+        name: Install Hadolint
+        command: |
+          if [ -d "/home/atom/hadolint" ]; then
+            cd ~/hadolint && git pull origin
+          else
+            git clone --depth=10 \
+              https://github.com/lukasmartinelli/hadolint \
+              ~/hadolint
+          fi
+          cd ~/hadolint && \
+          stack install --install-ghc hadolint
+    - run:
+        name: Hadolint version
+        command: hadolint --version
+    - run:
+        name: Create VFB for Atom to run in
+        command: /usr/local/bin/xvfb_start
+    - run:
+        name: Atom version
+        command: ${ATOM_SCRIPT_PATH} --version
+    - run:
+        name: APM version
+        command: ${APM_SCRIPT_PATH} --version
+    - run:
+        name: Package APM package dependencies
+        command: |
+          if [ -n "${APM_TEST_PACKAGES}" ]; then
+            for pack in ${APM_TEST_PACKAGES}; do
+            ${APM_SCRIPT_PATH} install "${pack}"
+            done
+          fi;
+    - run:
+        name: Package dependencies
+        command: ${APM_SCRIPT_PATH} install
+    - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
+    - run:
+        name: Package specs
+        command: ${ATOM_SCRIPT_PATH} --test spec
+    # Cache node_modules
+    - save_cache:
+        paths:
+          - node_modules
+        key: v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+    # Cache Stack and hadolint, keyed on hadolint binary
+    - save_cache:
+        paths:
+          - "~/.local"
+          - "~/.stack"
+          - "~/hadolint"
+        key: v1-hadolint-{{ arch }}-{{ checksum "/home/atom/.local/bin/hadolint" }}
 
 jobs:
   checkout_code:
     <<: *defaults
+    docker:
+      - image: circleci/node:latest
     steps:
       - checkout
-      - run:
-          name: Download Atom test script
-          command: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-      - run:
-          name: Make Atom script executable
-          command: chmod u+x build-package.sh
-      - run:
-          name: Download Hadolint
-          command: git clone https://github.com/lukasmartinelli/hadolint
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v2-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v2-dependencies
+          # Get latest cache for this package.json and package-lock.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v3-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v3-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp
           paths:
             - project
-
+  lint:
+    <<: *defaults
+    docker:
+      - image: circleci/node:lts
+    steps:
+      # Restore project state
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Node.js Version
+          command: node --version
+      - run:
+          name: NPM Version
+          command: npm --version
+      - run:
+          name: Install any remaining dependencies
+          command: npm install
+      - run:
+          name: Lint code
+          command: npm run lint
   stable:
     <<: *defaults
-    steps:
-      # Restore project state
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Update APT
-          command: sudo apt-get update
-      # Install some pre-requisite packages and missing dependencies from the atom package
-      - run:
-          name: Atom Prerequisites
-          command: sudo apt-get --assume-yes --quiet --no-install-suggests --no-install-recommends install sudo xvfb libxss1 libasound2
-      # Fire up a VFB to run Atom in
-      - run:
-          name: Create VFB for Atom to run in
-          command: /usr/bin/Xvfb $DISPLAY -ac -screen 0 1280x1024x16
-          background: true
-      - run:
-          name: Install Haskell
-          command: sudo apt-get --assume-yes --quiet --no-install-suggests install haskell-platform
-      - run:
-          name: Install Stack
-          command: curl -sSL https://get.haskellstack.org/ | sh
-      - run:
-          name: Add directory to PATH
-          command: echo 'export PATH=~/.local/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Print PATH
-          command: echo $PATH
-      - run:
-          name: Install Dependency Hadolint
-          command: cd hadolint && /usr/local/bin/stack install --install-ghc hadolint
-      - run:
-          name: Haskell version
-          command: ghc --version
-      - run:
-          name: Hadolint version
-          command: hadolint --version
-      - run:
-          name: Atom test
-          command: ./build-package.sh
-      # Cache node_modules
-      - save_cache:
-          paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
-
   beta:
     <<: *defaults
-    environment:
-      ATOM_CHANNEL: beta
-    steps:
-      # Restore project state
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Update APT
-          command: sudo apt-get update
-      # Install some pre-requisite packages and missing dependencies from the atom package
-      - run:
-          name: Atom Prerequisites
-          command: sudo apt-get --assume-yes --quiet --no-install-suggests --no-install-recommends install sudo xvfb libxss1 libasound2
-      # Fire up a VFB to run Atom in
-      - run:
-          name: Create VFB for Atom to run in
-          command: /usr/bin/Xvfb $DISPLAY -ac -screen 0 1280x1024x16
-          background: true
-      - run:
-          name: Install Haskell
-          command: sudo apt-get --assume-yes --quiet --no-install-suggests install haskell-platform
-      - run:
-          name: Install Stack
-          command: curl -sSL https://get.haskellstack.org/ | sh
-      - run:
-          name: Add directory to PATH
-          command: echo 'export PATH=~/.local/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Print PATH
-          command: echo $PATH
-      - run:
-          name: Install Dependency Hadolint
-          command: cd hadolint && /usr/local/bin/stack install --install-ghc hadolint
-      - run:
-          name: Haskell version
-          command: ghc --version
-      - run:
-          name: Hadolint version
-          command: hadolint --version
-      - run:
-          name: Atom test
-          command: ./build-package.sh
+    docker:
+      - image: arcanemagus/atom-docker-ci:beta
 
 workflows:
   version: 2
   test_package:
     jobs:
       - checkout_code
+      - lint:
+          requires:
+            - checkout_code
       - stable:
           requires:
-            - checkout_code
+            - lint
       - beta:
           requires:
-            - checkout_code
+            - lint


### PR DESCRIPTION
Update the CircleCI configuration to match the other repositories better, including:
* Utilizing arcanemagus/atom-docker-ci so Atom doesn't need to be reinstalled each build
* Caching hadolint builds so it doesn't need to be built from scratch each build
* Running code linting in a separate job so we don't run the full specs on invalid code