### PR TITLE
Use project directory as working directory when calling hadolint

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -132,6 +132,7 @@ module.exports = {
 
         const execPath = fs.normalize(applySubstitutions(this.executablePath, projectPath));
         const execOpts = {
+          cwd: projectPath,
           ignoreExitCode: true,
         };
 


### PR DESCRIPTION
hadolint supports a YAML [configuration file](https://github.com/hadolint/hadolint#configure), allowing to modify its behaviour for each project individually.

By [setting the working directory](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) when calling hadolint explicitly, this plugin respects these configuration files too.